### PR TITLE
Extension methods available in Selenium.WebDriver.Extensions namespace

### DIFF
--- a/Selenium.WebDriver.Extensions.sln.DotSettings
+++ b/Selenium.WebDriver.Extensions.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002Ehtml/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassWithVirtualMembersNeverInherited_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VirtualMemberNeverOverriden_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
@@ -9,4 +10,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=DoNotCallOverridableMethodsInConstructor/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/PsiConfigurationSettingsKey/LocationType/@EntryValue">SOLUTION_FOLDER</s:String>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/build.psm1
+++ b/build.psm1
@@ -74,7 +74,7 @@ function New-CoverageAnalysis {
     Exec {
           .\packages\OpenCover.4.5.3723\OpenCover.Console.exe -register:user `
           -target:.\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe `
-          "-targetargs:$testAssemblies -noshadow -parallel all" '-filter:$Filter' -output:$Output
+          "-targetargs:$testAssemblies -noshadow -parallel all" "-filter:$Filter" -output:$Output
     }
 }
 

--- a/src/Selenium.WebDriver.Extensions.Core/Selenium.WebDriver.Extensions.Core.nuspec
+++ b/src/Selenium.WebDriver.Extensions.Core/Selenium.WebDriver.Extensions.Core.nuspec
@@ -11,8 +11,8 @@
         <description>Core components for for Selenium WebDriver extensions.</description>
         <tags>selenium, extension, extensions, web, driver, webdriver, query selector, selector, selectors</tags>
         <dependencies>
-            <dependency id="Selenium.WebDriver" version="2.0.0"/>
-            <dependency id="Selenium.Support" version="2.0.0"/>
+            <dependency id="Selenium.WebDriver"/>
+            <dependency id="Selenium.Support"/>
         </dependencies> 
     </metadata>
     <files>

--- a/src/Selenium.WebDriver.Extensions.JQuery/Extensions/WebDriverExtensions.cs
+++ b/src/Selenium.WebDriver.Extensions.JQuery/Extensions/WebDriverExtensions.cs
@@ -31,6 +31,10 @@
         /// <param name="selector">The selector.</param>
         /// <returns>The jQuery helper.</returns>
         /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- jQuery variable name is empty.
+        /// </exception>
         public static ChainJQueryHelper JQuery(this IWebDriver driver, string selector)
         {
             if (driver == null)

--- a/src/Selenium.WebDriver.Extensions.JQuery/Extensions/WebDriverExtensions.cs
+++ b/src/Selenium.WebDriver.Extensions.JQuery/Extensions/WebDriverExtensions.cs
@@ -1,8 +1,14 @@
 ﻿namespace Selenium.WebDriver.Extensions.JQuery
 {
     using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Reflection;
+    using System.Reflection.Emit;
+    using System.Runtime.InteropServices;
     using OpenQA.Selenium;
-    
+    using Selenium.WebDriver.Extensions.Core;
+
     /// <summary>
     /// Web driver extensions.
     /// </summary>
@@ -60,6 +66,197 @@
             }
 
             return new ChainJQueryHelper(driver, selector);
+        }
+
+        /// <summary>
+        /// Returns the query selector helper, that can be used to access query selector specific functionalities.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <returns>The query selector helper.</returns>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        public static QuerySelectorHelper QuerySelector(this IWebDriver driver)
+        {
+            return Core.WebDriverExtensions.QuerySelector(driver);
+        }
+
+        /// <summary>
+        /// Searches for DOM element using given selector.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="selector">The Selenium selector.</param>
+        /// <returns>The first DOM element matching given JavaScript query selector.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Selector is null.
+        /// </exception>
+        /// <exception cref="NoSuchElementException">The requested element is not found.</exception>
+        /// <exception cref="InvalidOperationException">The source sequence is empty.</exception>
+        /// <exception cref="TargetInvocationException">The constructor being called throws an exception.</exception>
+        /// <exception cref="MethodAccessException">
+        /// The caller does not have permission to call this constructor.
+        /// </exception>
+        /// <exception cref="MemberAccessException">
+        /// Cannot create an instance of an abstract class, or this member was invoked with a late-binding mechanism.
+        /// </exception>
+        /// <exception cref="InvalidComObjectException">
+        /// The COM type was not obtained through <see cref="Type.GetTypeFromProgID(string)" /> or 
+        /// <see cref="Type.GetTypeFromCLSID(System.Guid)" />.
+        /// </exception>
+        /// <exception cref="MissingMethodException">No matching public constructor was found.</exception>
+        /// <exception cref="COMException">
+        /// Type is a COM object but the class identifier used to obtain the type is invalid, or the identified class 
+        /// is not registered.
+        /// </exception>
+        /// <exception cref="TypeLoadException">Type is not a valid type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Type is not a RuntimeType.
+        /// -or- Type is an open generic type (that is, the <see cref="P:System.Type.ContainsGenericParameters" /> 
+        /// property returns true).
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// Type cannot be a <see cref="TypeBuilder" />.
+        /// -or- Creation of <see cref="TypedReference" />, <see cref="ArgIterator" />, <see cref="Void" />, and 
+        /// <see cref="RuntimeArgumentHandle" /> types, or arrays of those types, is not supported.
+        /// -or- The assembly that contains type is a dynamic assembly that was created with 
+        /// <see cref="F:System.Reflection.Emit.AssemblyBuilderAccess.Save" />.
+        /// </exception>
+        public static WebElement FindElement(this IWebDriver driver, ISelector selector)
+        {
+            return Core.WebDriverExtensions.FindElement(driver, selector);
+        }
+
+        /// <summary>
+        /// Searches for DOM elements using given selector.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="selector">The selector.</param>
+        /// <returns>The DOM elements matching given JavaScript query selector.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Selector is null.
+        /// </exception>
+        /// <exception cref="TargetInvocationException">The constructor being called throws an exception.</exception>
+        /// <exception cref="MethodAccessException">
+        /// The caller does not have permission to call this constructor.
+        /// </exception>
+        /// <exception cref="MemberAccessException">
+        /// Cannot create an instance of an abstract class, or this member was invoked with a late-binding mechanism.
+        /// </exception>
+        /// <exception cref="InvalidComObjectException">
+        /// The COM type was not obtained through <see cref="Type.GetTypeFromProgID(string)" /> or 
+        /// <see cref="Type.GetTypeFromCLSID(System.Guid)" />.
+        /// </exception>
+        /// <exception cref="MissingMethodException">No matching public constructor was found.</exception>
+        /// <exception cref="COMException">
+        /// Type is a COM object but the class identifier used to obtain the type is invalid, or the identified class 
+        /// is not registered.
+        /// </exception>
+        /// <exception cref="TypeLoadException">Type is not a valid type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Type is not a RuntimeType.
+        /// -or- Type is an open generic type (that is, the <see cref="P:System.Type.ContainsGenericParameters" /> 
+        /// property returns true).
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// Type cannot be a <see cref="TypeBuilder" />.
+        /// -or- Creation of <see cref="TypedReference" />, <see cref="ArgIterator" />, <see cref="Void" />, and 
+        /// <see cref="RuntimeArgumentHandle" /> types, or arrays of those types, is not supported.
+        /// -or- The assembly that contains type is a dynamic assembly that was created with 
+        /// <see cref="F:System.Reflection.Emit.AssemblyBuilderAccess.Save" />.
+        /// </exception>
+        public static ReadOnlyCollection<WebElement> FindElements(this IWebDriver driver, ISelector selector)
+        {
+            return Core.WebDriverExtensions.FindElements(driver, selector);
+        }
+
+        /// <summary>
+        /// Executes JavaScript in the context of the currently selected frame or window.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="script">The script to be executed.</param>
+        /// <param name="args">The arguments to the script.</param>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        /// <exception cref="ArgumentException">Script is empty.</exception>
+        public static void ExecuteScript(this IWebDriver driver, string script, params object[] args)
+        {
+            Core.WebDriverExtensions.ExecuteScript(driver, script, args);
+        }
+
+        /// <summary>
+        /// Executes JavaScript in the context of the currently selected frame or window.
+        /// </summary>
+        /// <typeparam name="T">The type of the result.</typeparam>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="script">The script to be executed.</param>
+        /// <param name="args">The arguments to the script.</param>
+        /// <returns>The value returned by the script.</returns>
+        /// <remarks>
+        /// For an HTML element, this method returns a <see cref="IWebElement"/>.
+        /// For a number, a <see cref="long"/> is returned.
+        /// For a boolean, a <see cref="bool"/> is returned.
+        /// For all other cases a <see cref="string"/> is returned.
+        /// For an array,we check the first element, and attempt to return a <see cref="List{T}"/> of that type, 
+        /// following the rules above. Nested lists are not supported.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Script is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">Script is empty.</exception>
+        public static T ExecuteScript<T>(this IWebDriver driver, string script, params object[] args)
+        {
+            return Core.WebDriverExtensions.ExecuteScript<T>(driver, script, args);
+        }
+
+        /// <summary>
+        /// Checks if prerequisites for the selector has been met.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="loader">The loader.</param>
+        /// <returns><c>true</c> if prerequisites are met; otherwise, <c>false</c></returns>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Loader is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">Script is empty.</exception>
+        public static bool CheckSelectorPrerequisites(this IWebDriver driver, ILoader loader)
+        {
+            return Core.WebDriverExtensions.CheckSelectorPrerequisites(driver, loader);
+        }
+
+        /// <summary>
+        /// Checks if external library is loaded and loads it if needed.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="loader">The loader.</param>
+        /// <param name="libraryUri">
+        /// The URI of external library to load if it's not already loaded on the tested page.
+        /// </param>
+        /// <param name="timeout">The timeout value for the load.</param>
+        /// <remarks>
+        /// If external library is already loaded on a page this method will do nothing, even if the loaded version 
+        /// and version requested by invoking this method have different versions.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Loader is null.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// Value is less than <see cref="TimeSpan.MinValue" /> or greater than <see cref="TimeSpan.MaxValue" />.
+        /// -or- Value is <see cref="double.PositiveInfinity" />.
+        /// -or- Value is <see cref="double.NegativeInfinity" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">Value is equal to <see cref="double.NaN" />.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This instance represents a relative URI, and this property is valid only for absolute URIs.
+        /// </exception>
+        public static void LoadExternalLibrary(
+            this IWebDriver driver,
+            ILoader loader,
+            Uri libraryUri,
+            TimeSpan? timeout = null)
+        {
+            Core.WebDriverExtensions.LoadExternalLibrary(driver, loader, libraryUri, timeout);
         }
     }
 }

--- a/src/Selenium.WebDriver.Extensions.JQuery/Selenium.WebDriver.Extensions.JQuery.nuspec
+++ b/src/Selenium.WebDriver.Extensions.JQuery/Selenium.WebDriver.Extensions.JQuery.nuspec
@@ -11,8 +11,6 @@
         <description>jQuery selector support for Selenium WebDriver.</description>
         <tags>selenium, extension, extensions, web, driver, webdriver, jquery, selector, selectors</tags>
         <dependencies>
-			<dependency id="Selenium.WebDriver" version="2.0.0"/>
-            <dependency id="Selenium.Support" version="2.0.0"/>
             <dependency id="Selenium.WebDriver.Extensions.Core" version="$version$"/>
         </dependencies> 
     </metadata>

--- a/src/Selenium.WebDriver.Extensions.JQuery/Selenium.WebDriver.Extensions.JQuery.nuspec
+++ b/src/Selenium.WebDriver.Extensions.JQuery/Selenium.WebDriver.Extensions.JQuery.nuspec
@@ -11,6 +11,8 @@
         <description>jQuery selector support for Selenium WebDriver.</description>
         <tags>selenium, extension, extensions, web, driver, webdriver, jquery, selector, selectors</tags>
         <dependencies>
+			<dependency id="Selenium.WebDriver" version="2.0.0"/>
+            <dependency id="Selenium.Support" version="2.0.0"/>
             <dependency id="Selenium.WebDriver.Extensions.Core" version="$version$"/>
         </dependencies> 
     </metadata>

--- a/src/Selenium.WebDriver.Extensions.Sizzle/Extensions/WebDriverExtensions.cs
+++ b/src/Selenium.WebDriver.Extensions.Sizzle/Extensions/WebDriverExtensions.cs
@@ -1,8 +1,14 @@
 ﻿namespace Selenium.WebDriver.Extensions.Sizzle
 {
     using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Reflection;
+    using System.Reflection.Emit;
+    using System.Runtime.InteropServices;
     using OpenQA.Selenium;
-    
+    using Selenium.WebDriver.Extensions.Core;
+
     /// <summary>
     /// Web driver extensions.
     /// </summary>
@@ -22,6 +28,197 @@
             }
 
             return new SizzleHelper(driver);
+        }
+
+        /// <summary>
+        /// Returns the query selector helper, that can be used to access query selector specific functionalities.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <returns>The query selector helper.</returns>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        public static QuerySelectorHelper QuerySelector(this IWebDriver driver)
+        {
+            return Core.WebDriverExtensions.QuerySelector(driver);
+        }
+
+        /// <summary>
+        /// Searches for DOM element using given selector.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="selector">The Selenium selector.</param>
+        /// <returns>The first DOM element matching given JavaScript query selector.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Selector is null.
+        /// </exception>
+        /// <exception cref="NoSuchElementException">The requested element is not found.</exception>
+        /// <exception cref="InvalidOperationException">The source sequence is empty.</exception>
+        /// <exception cref="TargetInvocationException">The constructor being called throws an exception.</exception>
+        /// <exception cref="MethodAccessException">
+        /// The caller does not have permission to call this constructor.
+        /// </exception>
+        /// <exception cref="MemberAccessException">
+        /// Cannot create an instance of an abstract class, or this member was invoked with a late-binding mechanism.
+        /// </exception>
+        /// <exception cref="InvalidComObjectException">
+        /// The COM type was not obtained through <see cref="Type.GetTypeFromProgID(string)" /> or 
+        /// <see cref="Type.GetTypeFromCLSID(System.Guid)" />.
+        /// </exception>
+        /// <exception cref="MissingMethodException">No matching public constructor was found.</exception>
+        /// <exception cref="COMException">
+        /// Type is a COM object but the class identifier used to obtain the type is invalid, or the identified class 
+        /// is not registered.
+        /// </exception>
+        /// <exception cref="TypeLoadException">Type is not a valid type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Type is not a RuntimeType.
+        /// -or- Type is an open generic type (that is, the <see cref="P:System.Type.ContainsGenericParameters" /> 
+        /// property returns true).
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// Type cannot be a <see cref="TypeBuilder" />.
+        /// -or- Creation of <see cref="TypedReference" />, <see cref="ArgIterator" />, <see cref="Void" />, and 
+        /// <see cref="RuntimeArgumentHandle" /> types, or arrays of those types, is not supported.
+        /// -or- The assembly that contains type is a dynamic assembly that was created with 
+        /// <see cref="F:System.Reflection.Emit.AssemblyBuilderAccess.Save" />.
+        /// </exception>
+        public static WebElement FindElement(this IWebDriver driver, ISelector selector)
+        {
+            return Core.WebDriverExtensions.FindElement(driver, selector);
+        }
+
+        /// <summary>
+        /// Searches for DOM elements using given selector.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="selector">The selector.</param>
+        /// <returns>The DOM elements matching given JavaScript query selector.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Selector is null.
+        /// </exception>
+        /// <exception cref="TargetInvocationException">The constructor being called throws an exception.</exception>
+        /// <exception cref="MethodAccessException">
+        /// The caller does not have permission to call this constructor.
+        /// </exception>
+        /// <exception cref="MemberAccessException">
+        /// Cannot create an instance of an abstract class, or this member was invoked with a late-binding mechanism.
+        /// </exception>
+        /// <exception cref="InvalidComObjectException">
+        /// The COM type was not obtained through <see cref="Type.GetTypeFromProgID(string)" /> or 
+        /// <see cref="Type.GetTypeFromCLSID(System.Guid)" />.
+        /// </exception>
+        /// <exception cref="MissingMethodException">No matching public constructor was found.</exception>
+        /// <exception cref="COMException">
+        /// Type is a COM object but the class identifier used to obtain the type is invalid, or the identified class 
+        /// is not registered.
+        /// </exception>
+        /// <exception cref="TypeLoadException">Type is not a valid type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Type is not a RuntimeType.
+        /// -or- Type is an open generic type (that is, the <see cref="P:System.Type.ContainsGenericParameters" /> 
+        /// property returns true).
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// Type cannot be a <see cref="TypeBuilder" />.
+        /// -or- Creation of <see cref="TypedReference" />, <see cref="ArgIterator" />, <see cref="Void" />, and 
+        /// <see cref="RuntimeArgumentHandle" /> types, or arrays of those types, is not supported.
+        /// -or- The assembly that contains type is a dynamic assembly that was created with 
+        /// <see cref="F:System.Reflection.Emit.AssemblyBuilderAccess.Save" />.
+        /// </exception>
+        public static ReadOnlyCollection<WebElement> FindElements(this IWebDriver driver, ISelector selector)
+        {
+            return Core.WebDriverExtensions.FindElements(driver, selector);
+        }
+
+        /// <summary>
+        /// Executes JavaScript in the context of the currently selected frame or window.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="script">The script to be executed.</param>
+        /// <param name="args">The arguments to the script.</param>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        /// <exception cref="ArgumentException">Script is empty.</exception>
+        public static void ExecuteScript(this IWebDriver driver, string script, params object[] args)
+        {
+            Core.WebDriverExtensions.ExecuteScript(driver, script, args);
+        }
+
+        /// <summary>
+        /// Executes JavaScript in the context of the currently selected frame or window.
+        /// </summary>
+        /// <typeparam name="T">The type of the result.</typeparam>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="script">The script to be executed.</param>
+        /// <param name="args">The arguments to the script.</param>
+        /// <returns>The value returned by the script.</returns>
+        /// <remarks>
+        /// For an HTML element, this method returns a <see cref="IWebElement"/>.
+        /// For a number, a <see cref="long"/> is returned.
+        /// For a boolean, a <see cref="bool"/> is returned.
+        /// For all other cases a <see cref="string"/> is returned.
+        /// For an array,we check the first element, and attempt to return a <see cref="List{T}"/> of that type, 
+        /// following the rules above. Nested lists are not supported.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Script is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">Script is empty.</exception>
+        public static T ExecuteScript<T>(this IWebDriver driver, string script, params object[] args)
+        {
+            return Core.WebDriverExtensions.ExecuteScript<T>(driver, script, args);
+        }
+
+        /// <summary>
+        /// Checks if prerequisites for the selector has been met.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="loader">The loader.</param>
+        /// <returns><c>true</c> if prerequisites are met; otherwise, <c>false</c></returns>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Loader is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">Script is empty.</exception>
+        public static bool CheckSelectorPrerequisites(this IWebDriver driver, ILoader loader)
+        {
+            return Core.WebDriverExtensions.CheckSelectorPrerequisites(driver, loader);
+        }
+
+        /// <summary>
+        /// Checks if external library is loaded and loads it if needed.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="loader">The loader.</param>
+        /// <param name="libraryUri">
+        /// The URI of external library to load if it's not already loaded on the tested page.
+        /// </param>
+        /// <param name="timeout">The timeout value for the load.</param>
+        /// <remarks>
+        /// If external library is already loaded on a page this method will do nothing, even if the loaded version 
+        /// and version requested by invoking this method have different versions.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Loader is null.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// Value is less than <see cref="TimeSpan.MinValue" /> or greater than <see cref="TimeSpan.MaxValue" />.
+        /// -or- Value is <see cref="double.PositiveInfinity" />.
+        /// -or- Value is <see cref="double.NegativeInfinity" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">Value is equal to <see cref="double.NaN" />.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This instance represents a relative URI, and this property is valid only for absolute URIs.
+        /// </exception>
+        public static void LoadExternalLibrary(
+            this IWebDriver driver,
+            ILoader loader,
+            Uri libraryUri,
+            TimeSpan? timeout = null)
+        {
+            Core.WebDriverExtensions.LoadExternalLibrary(driver, loader, libraryUri, timeout);
         }
     }
 }

--- a/src/Selenium.WebDriver.Extensions.Sizzle/Selenium.WebDriver.Extensions.Sizzle.nuspec
+++ b/src/Selenium.WebDriver.Extensions.Sizzle/Selenium.WebDriver.Extensions.Sizzle.nuspec
@@ -11,8 +11,6 @@
         <description>Sizzle selector support for Selenium WebDriver.</description>
         <tags>selenium, extension, extensions, web, driver, webdriver, Sizzle, selector, selectors</tags>
         <dependencies>
-			<dependency id="Selenium.WebDriver" version="2.0.0"/>
-            <dependency id="Selenium.Support" version="2.0.0"/>
             <dependency id="Selenium.WebDriver.Extensions.Core" version="$version$"/>
         </dependencies> 
     </metadata>

--- a/src/Selenium.WebDriver.Extensions.Sizzle/Selenium.WebDriver.Extensions.Sizzle.nuspec
+++ b/src/Selenium.WebDriver.Extensions.Sizzle/Selenium.WebDriver.Extensions.Sizzle.nuspec
@@ -11,6 +11,8 @@
         <description>Sizzle selector support for Selenium WebDriver.</description>
         <tags>selenium, extension, extensions, web, driver, webdriver, Sizzle, selector, selectors</tags>
         <dependencies>
+			<dependency id="Selenium.WebDriver" version="2.0.0"/>
+            <dependency id="Selenium.Support" version="2.0.0"/>
             <dependency id="Selenium.WebDriver.Extensions.Core" version="$version$"/>
         </dependencies> 
     </metadata>

--- a/src/Selenium.WebDriver.Extensions/Extensions/WebDriverExtensions.cs
+++ b/src/Selenium.WebDriver.Extensions/Extensions/WebDriverExtensions.cs
@@ -1,0 +1,256 @@
+﻿namespace Selenium.WebDriver.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Reflection;
+    using System.Reflection.Emit;
+    using System.Runtime.InteropServices;
+    using OpenQA.Selenium;
+    using Selenium.WebDriver.Extensions.Core;
+    using Selenium.WebDriver.Extensions.JQuery;
+    using Selenium.WebDriver.Extensions.Sizzle;
+
+    /// <summary>
+    /// Web driver extensions.
+    /// </summary>
+    public static class WebDriverExtensions
+    {
+        /// <summary>
+        /// Returns the query selector helper, that can be used to access query selector specific functionalities.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <returns>The query selector helper.</returns>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        public static QuerySelectorHelper QuerySelector(this IWebDriver driver)
+        {
+            return Core.WebDriverExtensions.QuerySelector(driver);
+        }
+
+        /// <summary>
+        /// Searches for DOM element using given selector.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="selector">The Selenium selector.</param>
+        /// <returns>The first DOM element matching given JavaScript query selector.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Selector is null.
+        /// </exception>
+        /// <exception cref="NoSuchElementException">The requested element is not found.</exception>
+        /// <exception cref="InvalidOperationException">The source sequence is empty.</exception>
+        /// <exception cref="TargetInvocationException">The constructor being called throws an exception.</exception>
+        /// <exception cref="MethodAccessException">
+        /// The caller does not have permission to call this constructor.
+        /// </exception>
+        /// <exception cref="MemberAccessException">
+        /// Cannot create an instance of an abstract class, or this member was invoked with a late-binding mechanism.
+        /// </exception>
+        /// <exception cref="InvalidComObjectException">
+        /// The COM type was not obtained through <see cref="Type.GetTypeFromProgID(string)" /> or 
+        /// <see cref="Type.GetTypeFromCLSID(System.Guid)" />.
+        /// </exception>
+        /// <exception cref="MissingMethodException">No matching public constructor was found.</exception>
+        /// <exception cref="COMException">
+        /// Type is a COM object but the class identifier used to obtain the type is invalid, or the identified class 
+        /// is not registered.
+        /// </exception>
+        /// <exception cref="TypeLoadException">Type is not a valid type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Type is not a RuntimeType.
+        /// -or- Type is an open generic type (that is, the <see cref="P:System.Type.ContainsGenericParameters" /> 
+        /// property returns true).
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// Type cannot be a <see cref="TypeBuilder" />.
+        /// -or- Creation of <see cref="TypedReference" />, <see cref="ArgIterator" />, <see cref="Void" />, and 
+        /// <see cref="RuntimeArgumentHandle" /> types, or arrays of those types, is not supported.
+        /// -or- The assembly that contains type is a dynamic assembly that was created with 
+        /// <see cref="F:System.Reflection.Emit.AssemblyBuilderAccess.Save" />.
+        /// </exception>
+        public static WebElement FindElement(this IWebDriver driver, ISelector selector)
+        {
+            return Core.WebDriverExtensions.FindElement(driver, selector);
+        }
+
+        /// <summary>
+        /// Searches for DOM elements using given selector.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="selector">The selector.</param>
+        /// <returns>The DOM elements matching given JavaScript query selector.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Selector is null.
+        /// </exception>
+        /// <exception cref="TargetInvocationException">The constructor being called throws an exception.</exception>
+        /// <exception cref="MethodAccessException">
+        /// The caller does not have permission to call this constructor.
+        /// </exception>
+        /// <exception cref="MemberAccessException">
+        /// Cannot create an instance of an abstract class, or this member was invoked with a late-binding mechanism.
+        /// </exception>
+        /// <exception cref="InvalidComObjectException">
+        /// The COM type was not obtained through <see cref="Type.GetTypeFromProgID(string)" /> or 
+        /// <see cref="Type.GetTypeFromCLSID(System.Guid)" />.
+        /// </exception>
+        /// <exception cref="MissingMethodException">No matching public constructor was found.</exception>
+        /// <exception cref="COMException">
+        /// Type is a COM object but the class identifier used to obtain the type is invalid, or the identified class 
+        /// is not registered.
+        /// </exception>
+        /// <exception cref="TypeLoadException">Type is not a valid type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Type is not a RuntimeType.
+        /// -or- Type is an open generic type (that is, the <see cref="P:System.Type.ContainsGenericParameters" /> 
+        /// property returns true).
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// Type cannot be a <see cref="TypeBuilder" />.
+        /// -or- Creation of <see cref="TypedReference" />, <see cref="ArgIterator" />, <see cref="Void" />, and 
+        /// <see cref="RuntimeArgumentHandle" /> types, or arrays of those types, is not supported.
+        /// -or- The assembly that contains type is a dynamic assembly that was created with 
+        /// <see cref="F:System.Reflection.Emit.AssemblyBuilderAccess.Save" />.
+        /// </exception>
+        public static ReadOnlyCollection<WebElement> FindElements(this IWebDriver driver, ISelector selector)
+        {
+            return Core.WebDriverExtensions.FindElements(driver, selector);
+        }
+
+        /// <summary>
+        /// Executes JavaScript in the context of the currently selected frame or window.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="script">The script to be executed.</param>
+        /// <param name="args">The arguments to the script.</param>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        /// <exception cref="ArgumentException">Script is empty.</exception>
+        public static void ExecuteScript(this IWebDriver driver, string script, params object[] args)
+        {
+            Core.WebDriverExtensions.ExecuteScript(driver, script, args);
+        }
+
+        /// <summary>
+        /// Executes JavaScript in the context of the currently selected frame or window.
+        /// </summary>
+        /// <typeparam name="T">The type of the result.</typeparam>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="script">The script to be executed.</param>
+        /// <param name="args">The arguments to the script.</param>
+        /// <returns>The value returned by the script.</returns>
+        /// <remarks>
+        /// For an HTML element, this method returns a <see cref="IWebElement"/>.
+        /// For a number, a <see cref="long"/> is returned.
+        /// For a boolean, a <see cref="bool"/> is returned.
+        /// For all other cases a <see cref="string"/> is returned.
+        /// For an array,we check the first element, and attempt to return a <see cref="List{T}"/> of that type, 
+        /// following the rules above. Nested lists are not supported.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Script is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">Script is empty.</exception>
+        public static T ExecuteScript<T>(this IWebDriver driver, string script, params object[] args)
+        {
+            return Core.WebDriverExtensions.ExecuteScript<T>(driver, script, args);
+        }
+
+        /// <summary>
+        /// Checks if prerequisites for the selector has been met.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="loader">The loader.</param>
+        /// <returns><c>true</c> if prerequisites are met; otherwise, <c>false</c></returns>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Loader is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">Script is empty.</exception>
+        public static bool CheckSelectorPrerequisites(this IWebDriver driver, ILoader loader)
+        {
+            return Core.WebDriverExtensions.CheckSelectorPrerequisites(driver, loader);
+        }
+
+        /// <summary>
+        /// Checks if external library is loaded and loads it if needed.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="loader">The loader.</param>
+        /// <param name="libraryUri">
+        /// The URI of external library to load if it's not already loaded on the tested page.
+        /// </param>
+        /// <param name="timeout">The timeout value for the load.</param>
+        /// <remarks>
+        /// If external library is already loaded on a page this method will do nothing, even if the loaded version 
+        /// and version requested by invoking this method have different versions.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Driver is null.
+        /// -or- Loader is null.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// Value is less than <see cref="TimeSpan.MinValue" /> or greater than <see cref="TimeSpan.MaxValue" />.
+        /// -or- Value is <see cref="double.PositiveInfinity" />.
+        /// -or- Value is <see cref="double.NegativeInfinity" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">Value is equal to <see cref="double.NaN" />.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This instance represents a relative URI, and this property is valid only for absolute URIs.
+        /// </exception>
+        public static void LoadExternalLibrary(
+            this IWebDriver driver,
+            ILoader loader,
+            Uri libraryUri,
+            TimeSpan? timeout = null)
+        {
+            Core.WebDriverExtensions.LoadExternalLibrary(driver, loader, libraryUri, timeout);
+        }
+
+        /// <summary>
+        /// Returns the jQuery helper, that can be used to access jQuery-specific functionalities.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <returns>The jQuery helper.</returns>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        public static JQueryHelper JQuery(this IWebDriver driver)
+        {
+            return Extensions.JQuery.WebDriverExtensions.JQuery(driver);
+        }
+
+        /// <summary>
+        /// Returns the jQuery helper, that can be used to access jQuery-specific functionalities.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="selector">The selector.</param>
+        /// <returns>The jQuery helper.</returns>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        public static ChainJQueryHelper JQuery(this IWebDriver driver, string selector)
+        {
+            return Extensions.JQuery.WebDriverExtensions.JQuery(driver, selector);
+        }
+
+        /// <summary>
+        /// Returns the jQuery helper, that can be used to access jQuery-specific functionalities.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <param name="selector">The selector.</param>
+        /// <returns>The jQuery helper.</returns>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        public static ChainJQueryHelper JQuery(this IWebDriver driver, JQuerySelector selector)
+        {
+            return Extensions.JQuery.WebDriverExtensions.JQuery(driver, selector);
+        }
+
+        /// <summary>
+        /// Returns the Sizzle helper, that can be used to access Sizzle-specific functionalities.
+        /// </summary>
+        /// <param name="driver">The Selenium web driver.</param>
+        /// <returns>The Sizzle helper.</returns>
+        /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        public static SizzleHelper Sizzle(this IWebDriver driver)
+        {
+            return Extensions.Sizzle.WebDriverExtensions.Sizzle(driver);
+        }
+    }
+}

--- a/src/Selenium.WebDriver.Extensions/Extensions/WebDriverExtensions.cs
+++ b/src/Selenium.WebDriver.Extensions/Extensions/WebDriverExtensions.cs
@@ -225,6 +225,10 @@
         /// <param name="selector">The selector.</param>
         /// <returns>The jQuery helper.</returns>
         /// <exception cref="ArgumentNullException">Driver is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- jQuery variable name is empty.
+        /// </exception>
         public static ChainJQueryHelper JQuery(this IWebDriver driver, string selector)
         {
             return Extensions.JQuery.WebDriverExtensions.JQuery(driver, selector);

--- a/src/Selenium.WebDriver.Extensions/Extensions/WebElementExtensions.cs
+++ b/src/Selenium.WebDriver.Extensions/Extensions/WebElementExtensions.cs
@@ -1,0 +1,45 @@
+﻿namespace Selenium.WebDriver.Extensions
+{
+    using System;
+    using Selenium.WebDriver.Extensions.Core;
+    using Selenium.WebDriver.Extensions.JQuery;
+
+    /// <summary>
+    /// The web element extensions.
+    /// </summary>
+    public static class WebElementExtensions
+    {
+        /// <summary>
+        /// Returns the jQuery helper, that can be used to access jQuery-specific functionalities.
+        /// </summary>
+        /// <param name="webElement">The web element to base the search on.</param>
+        /// <param name="selector">The selector.</param>
+        /// <returns>The jQuery helper.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Web element is null.
+        /// -or- Selector is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- jQuery variable name is empty.
+        /// </exception>
+        public static ChainJQueryHelper JQuery(this WebElement webElement, string selector)
+        {
+            return Extensions.JQuery.WebElementExtensions.JQuery(webElement, selector);
+        }
+
+        /// <summary>
+        /// Returns the jQuery helper, that can be used to access jQuery-specific functionalities.
+        /// </summary>
+        /// <param name="webElement">The web element to base the search on.</param>
+        /// <param name="selector">The selector.</param>
+        /// <returns>The jQuery helper.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Web element is null.
+        /// -or- Selector is null.
+        /// </exception>
+        public static ChainJQueryHelper JQuery(this WebElement webElement, JQuerySelector selector)
+        {
+            return Extensions.JQuery.WebElementExtensions.JQuery(webElement, selector);
+        }
+    }
+}

--- a/src/Selenium.WebDriver.Extensions/Models/By.cs
+++ b/src/Selenium.WebDriver.Extensions/Models/By.cs
@@ -1,5 +1,6 @@
 ﻿namespace Selenium.WebDriver.Extensions
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using JetBrains.Annotations;
     using Selenium.WebDriver.Extensions.Core;
@@ -23,6 +24,13 @@
         /// <param name="context">A DOM Element, Document, or jQuery to use as context.</param>
         /// <param name="jQueryVariable">A variable that has been assigned to jQuery.</param>
         /// <returns>A <see cref="JQuerySelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Selector is null.
+        /// -or- jQuery variable name is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- jQuery variable name is empty.
+        /// </exception>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "j")]
         public static JQuerySelector JQuerySelector(
             string selector, 
@@ -38,6 +46,8 @@
         /// <param name="selector">A string containing a selector expression.</param>
         /// <param name="context">A DOM Element, Document, or jQuery to use as context.</param>
         /// <returns>A <see cref="SizzleSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">Selector is null.</exception>
+        /// <exception cref="ArgumentException">Selector is empty.</exception>
         public static SizzleSelector SizzleSelector(
             string selector,
             SizzleSelector context = null)
@@ -56,6 +66,14 @@
         /// A <see cref="Selenium.WebDriver.Extensions.Core.QuerySelector"/> object the driver can use to find the 
         /// elements.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Selector is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static QuerySelector QuerySelector(string selector, string baseElement = "document")
         {
             return Core.By.QuerySelector(selector, baseElement);
@@ -70,6 +88,11 @@
         /// A <see cref="Selenium.WebDriver.Extensions.Core.QuerySelector"/> object the driver can use to find the 
         /// elements.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Selector is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">Selector is empty.</exception>
         public static QuerySelector QuerySelector(string selector, ISelector baseSelector)
         {
             return Core.By.QuerySelector(selector, baseSelector);
@@ -80,6 +103,14 @@
         /// </summary>
         /// <param name="classNameToFind">The CSS class to find.</param>
         /// <returns>A <see cref="ClassNameSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Selector is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static new ClassNameSelector ClassName(string classNameToFind)
         {
             return Core.By.ClassName(classNameToFind);
@@ -90,6 +121,14 @@
         /// </summary>
         /// <param name="cssSelectorToFind">The CSS selector to find.</param>
         /// <returns>A <see cref="CssSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Selector is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static new CssSelector CssSelector(string cssSelectorToFind)
         {
             return Core.By.CssSelector(cssSelectorToFind);
@@ -100,6 +139,14 @@
         /// </summary>
         /// <param name="idToFind">The ID to find.</param>
         /// <returns>An <see cref="IdSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Selector is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static new IdSelector Id(string idToFind)
         {
             return Core.By.Id(idToFind);
@@ -110,6 +157,14 @@
         /// </summary>
         /// <param name="linkTextToFind">The link text to find.</param>
         /// <returns>A <see cref="LinkTextSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Text is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Text is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static new LinkTextSelector LinkText(string linkTextToFind)
         {
             return Core.By.LinkText(linkTextToFind);
@@ -123,6 +178,14 @@
         /// A string defining the base element on which base element the selector should be invoked.
         /// </param>
         /// <returns>A <see cref="LinkTextSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Text is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Text is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static LinkTextSelector LinkText(string linkTextToFind, string baseElement)
         {
             return Core.By.LinkText(linkTextToFind, baseElement);
@@ -133,6 +196,14 @@
         /// </summary>
         /// <param name="nameToFind">The name to find.</param>
         /// <returns>A <see cref="NameSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Selector is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static new NameSelector Name(string nameToFind)
         {
             return Core.By.Name(nameToFind);
@@ -143,6 +214,14 @@
         /// </summary>
         /// <param name="partialLinkTextToFind">The partial link text to find.</param>
         /// <returns>A <see cref="PartialLinkTextSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Text is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Text is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static new PartialLinkTextSelector PartialLinkText(string partialLinkTextToFind)
         {
             return Core.By.PartialLinkText(partialLinkTextToFind);
@@ -156,6 +235,14 @@
         /// A string defining the base element on which base element the selector should be invoked.
         /// </param>
         /// <returns>A <see cref="PartialLinkTextSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Text is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Text is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static PartialLinkTextSelector PartialLinkText(string partialLinkTextToFind, string baseElement)
         {
             return Core.By.PartialLinkText(partialLinkTextToFind, baseElement);
@@ -166,6 +253,14 @@
         /// </summary>
         /// <param name="tagNameToFind">The tag name to find.</param>
         /// <returns>A <see cref="TagNameSelector"/> selector object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Selector is null.
+        /// -or- Base element is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Selector is empty.
+        /// -or- Base element is empty.
+        /// </exception>
         public static new TagNameSelector TagName(string tagNameToFind)
         {
             return Core.By.TagName(tagNameToFind);
@@ -179,6 +274,8 @@
         /// </summary>
         /// <param name="xpathToFind">The XPath query to use.</param>
         /// <returns>A <see cref="XPathSelector"/> object the driver can use to find the elements.</returns>
+        /// <exception cref="ArgumentNullException">XPATH is null.</exception>
+        /// <exception cref="ArgumentException">XPATH is empty.</exception>
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "XPath")]
         public static new XPathSelector XPath(string xpathToFind)
         {

--- a/src/Selenium.WebDriver.Extensions/Selenium.WebDriver.Extensions.csproj
+++ b/src/Selenium.WebDriver.Extensions/Selenium.WebDriver.Extensions.csproj
@@ -117,6 +117,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\WebDriverExtensions.cs" />
+    <Compile Include="Extensions\WebElementExtensions.cs" />
     <Compile Include="Models\By.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Selenium.WebDriver.Extensions/Selenium.WebDriver.Extensions.csproj.DotSettings
+++ b/src/Selenium.WebDriver.Extensions/Selenium.WebDriver.Extensions.csproj.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=extensions/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=models/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Selenium.WebDriver.Extensions/Selenium.WebDriver.Extensions.nuspec
+++ b/src/Selenium.WebDriver.Extensions/Selenium.WebDriver.Extensions.nuspec
@@ -11,6 +11,8 @@
         <description>Contains all Selenium WebDriver extensions including jQuery, Sizzle and query selector support..</description>
         <tags>selenium, extension, extensions, web, driver, webdriver, jquery, sizzle, queryselector, selector, selectors</tags>
         <dependencies>
+			<dependency id="Selenium.WebDriver" version="2.0.0"/>
+            <dependency id="Selenium.Support" version="2.0.0"/>
             <dependency id="Selenium.WebDriver.Extensions.JQuery" version="$version$"/>
             <dependency id="Selenium.WebDriver.Extensions.Sizzle" version="$version$"/>
         </dependencies> 

--- a/src/Selenium.WebDriver.Extensions/Selenium.WebDriver.Extensions.nuspec
+++ b/src/Selenium.WebDriver.Extensions/Selenium.WebDriver.Extensions.nuspec
@@ -11,8 +11,6 @@
         <description>Contains all Selenium WebDriver extensions including jQuery, Sizzle and query selector support..</description>
         <tags>selenium, extension, extensions, web, driver, webdriver, jquery, sizzle, queryselector, selector, selectors</tags>
         <dependencies>
-			<dependency id="Selenium.WebDriver" version="2.0.0"/>
-            <dependency id="Selenium.Support" version="2.0.0"/>
             <dependency id="Selenium.WebDriver.Extensions.JQuery" version="$version$"/>
             <dependency id="Selenium.WebDriver.Extensions.Sizzle" version="$version$"/>
         </dependencies> 

--- a/test/Selenium.WebDriver.Extensions.Core.Tests/Selenium.WebDriver.Extensions.Core.Tests.csproj
+++ b/test/Selenium.WebDriver.Extensions.Core.Tests/Selenium.WebDriver.Extensions.Core.Tests.csproj
@@ -78,9 +78,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\StringExtensions.IsNullOrWhiteSpaceTests.cs" />
-    <Compile Include="Extensions\WebDriverExtensions.FindElementTests.cs" />
-    <Compile Include="Extensions\WebDriverExtensions.FindElementsTests.cs" />
-    <Compile Include="Extensions\WebDriverExtensions.OtherTests.cs" />
     <Compile Include="Loaders\QuerySelectorLoaderTests.cs" />
     <Compile Include="Models\ByTests.cs" />
     <Compile Include="Models\QuerySelectorHelperTests.cs" />

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.CoreChromeTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.CoreChromeTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Chrome")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsCoreChromeTests : WebDriverExtensionsCoreTests, IClassFixture<ChromeFixture>
     {
         public WebDriverExtensionsCoreChromeTests(ChromeFixture fixture)

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.JQueryLoadedSelectorChromeTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.JQueryLoadedSelectorChromeTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Chrome")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryLoadedSelectorChromeTests : 
         WebDriverExtensionsJQuerySelectorTests, IClassFixture<ChromeFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.JQueryLoadedSetterChromeTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.JQueryLoadedSetterChromeTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Chrome")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryLoadedSetterChromeTests :
         WebDriverExtensionsJQuerySetterTests, IClassFixture<ChromeFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.JQueryUnloadedSelectorChromeTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.JQueryUnloadedSelectorChromeTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Chrome")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryUnloadedSelectorChromeTests :
         WebDriverExtensionsJQuerySelectorTests, IClassFixture<ChromeFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.JQueryUnloadedSetterChromeTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.JQueryUnloadedSetterChromeTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Chrome")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryUnloadedSetterChromeTests :
         WebDriverExtensionsJQuerySetterTests, IClassFixture<ChromeFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.QuerySelectorChromeTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.QuerySelectorChromeTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Chrome")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsQuerySelectorChromeTests : 
         WebDriverExtensionsQuerySelectorTests, IClassFixture<ChromeFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.SizzleLoadedSelectorChromeTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.SizzleLoadedSelectorChromeTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Chrome")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsSizzleLoadedSelectorChromeTests : 
         WebDriverExtensionsSizzleSelectorTests, IClassFixture<ChromeFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.SizzleUnloadedSelectorChromeTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/ChromeTests/WebDriverExtensions.SizzleUnloadedSelectorChromeTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Chrome")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsSizzleUnloadedSelectorChromeTests :
         WebDriverExtensionsSizzleSelectorTests, IClassFixture<ChromeFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.CoreFirefoxTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.CoreFirefoxTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Firefox")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsCoreFirefoxTests : WebDriverExtensionsCoreTests, IClassFixture<FirefoxFixture>
     {
         public WebDriverExtensionsCoreFirefoxTests(FirefoxFixture fixture)

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.JQueryLoadedSelectorFirefoxTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.JQueryLoadedSelectorFirefoxTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Firefox")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryLoadedSelectorFirefoxTests : 
         WebDriverExtensionsJQuerySelectorTests, IClassFixture<FirefoxFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.JQueryLoadedSetterFirefoxTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.JQueryLoadedSetterFirefoxTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Firefox")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryLoadedSetterFirefoxTests :
         WebDriverExtensionsJQuerySetterTests, IClassFixture<FirefoxFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.JQueryUnloadedSelectorFirefoxTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.JQueryUnloadedSelectorFirefoxTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Firefox")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryUnloadedSelectorFirefoxTests :
         WebDriverExtensionsJQuerySelectorTests, IClassFixture<FirefoxFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.JQueryUnloadedSetterFirefoxTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.JQueryUnloadedSetterFirefoxTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Firefox")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryUnloadedSetterFirefoxTests :
         WebDriverExtensionsJQuerySetterTests, IClassFixture<FirefoxFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.QuerySelectorFirefoxTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.QuerySelectorFirefoxTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Firefox")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsQuerySelectorFirefoxTests : 
         WebDriverExtensionsQuerySelectorTests, IClassFixture<FirefoxFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.SizzleLoadedSelectorFirefoxTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.SizzleLoadedSelectorFirefoxTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Firefox")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsSizzleLoadedSelectorFirefoxTests : 
         WebDriverExtensionsSizzleSelectorTests, IClassFixture<FirefoxFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.SizzleUnloadedSelectorFirefoxTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/FirefoxTests/WebDriverExtensions.SizzleUnloadedSelectorFirefoxTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "Firefox")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsSizzleUnloadedSelectorFirefoxTests :
         WebDriverExtensionsSizzleSelectorTests, IClassFixture<FirefoxFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/Fixtures/ChromeFixture.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/Fixtures/ChromeFixture.cs
@@ -6,6 +6,7 @@
     using OpenQA.Selenium.Chrome;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class ChromeFixture : IDisposable
     {
         public ChromeFixture()

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/Fixtures/FirefoxFixture.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/Fixtures/FirefoxFixture.cs
@@ -6,6 +6,7 @@
     using OpenQA.Selenium.Firefox;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class FirefoxFixture : IDisposable
     {
         public FirefoxFixture()

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/Fixtures/InternetExplorerFixture.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/Fixtures/InternetExplorerFixture.cs
@@ -6,6 +6,7 @@
     using OpenQA.Selenium.IE;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class InternetExplorerFixture : IDisposable
     {
         public InternetExplorerFixture()

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/Fixtures/PhantomJsFixture.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/Fixtures/PhantomJsFixture.cs
@@ -6,6 +6,7 @@
     using OpenQA.Selenium.PhantomJS;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class PhantomJsFixture : IDisposable
     {
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.CoreInternetExplorerTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.CoreInternetExplorerTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "InternetExplorer")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsCoreInternetExplorerTests : WebDriverExtensionsCoreTests, 
         IClassFixture<InternetExplorerFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.JQueryLoadedSelectorInternetExplorerTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.JQueryLoadedSelectorInternetExplorerTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "InternetExplorer")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryLoadedSelectorInternetExplorerTests : 
         WebDriverExtensionsJQuerySelectorTests, IClassFixture<InternetExplorerFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.JQueryLoadedSetterInternetExplorerTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.JQueryLoadedSetterInternetExplorerTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "InternetExplorer")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryLoadedSetterInternetExplorerTests :
         WebDriverExtensionsJQuerySetterTests, IClassFixture<InternetExplorerFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.JQueryUnloadedSelectorInternetExplorerTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.JQueryUnloadedSelectorInternetExplorerTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "InternetExplorer")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryUnloadedSelectorInternetExplorerTests :
         WebDriverExtensionsJQuerySelectorTests, IClassFixture<InternetExplorerFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.JQueryUnloadedSetterInternetExplorerTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.JQueryUnloadedSetterInternetExplorerTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "InternetExplorer")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryUnloadedSetterInternetExplorerTests :
         WebDriverExtensionsJQuerySetterTests, IClassFixture<InternetExplorerFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.QuerySelectorInternetExplorerTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.QuerySelectorInternetExplorerTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "InternetExplorer")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsQuerySelectorInternetExplorerTests : 
         WebDriverExtensionsQuerySelectorTests, IClassFixture<InternetExplorerFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.SizzleLoadedSelectorInternetExplorerTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.SizzleLoadedSelectorInternetExplorerTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "InternetExplorer")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsSizzleLoadedSelectorInternetExplorerTests : 
         WebDriverExtensionsSizzleSelectorTests, IClassFixture<InternetExplorerFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.SizzleUnloadedSelectorInternetExplorerTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/InternetExplorerTests/WebDriverExtensions.SizzleUnloadedSelectorInternetExplorerTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "InternetExplorer")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsSizzleUnloadedSelectorInternetExplorerTests :
         WebDriverExtensionsSizzleSelectorTests, IClassFixture<InternetExplorerFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.CorePhantomJsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.CorePhantomJsTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "PhantomJS")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsCorePhantomJsTests : WebDriverExtensionsCoreTests, 
         IClassFixture<PhantomJsFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.JQueryLoadedSelectorPhantomJsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.JQueryLoadedSelectorPhantomJsTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "PhantomJs")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryLoadedSelectorPhantomJsTests : 
         WebDriverExtensionsJQuerySelectorTests, IClassFixture<PhantomJsFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.JQueryLoadedSetterPhantomJsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.JQueryLoadedSetterPhantomJsTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "PhantomJs")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryLoadedSetterPhantomJsTests :
         WebDriverExtensionsJQuerySetterTests, IClassFixture<PhantomJsFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.JQueryUnloadedSelectorPhantomJsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.JQueryUnloadedSelectorPhantomJsTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "PhantomJs")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryUnloadedSelectorPhantomJsTests :
         WebDriverExtensionsJQuerySelectorTests, IClassFixture<PhantomJsFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.JQueryUnloadedSetterPhantomJsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.JQueryUnloadedSetterPhantomJsTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "PhantomJs")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsJQueryUnloadedSetterPhantomJsTests :
         WebDriverExtensionsJQuerySetterTests, IClassFixture<PhantomJsFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.QuerySelectorPhantomJsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.QuerySelectorPhantomJsTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "PhantomJs")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsQuerySelectorPhantomJsTests : 
         WebDriverExtensionsQuerySelectorTests, IClassFixture<PhantomJsFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.SizzleLoadedSelectorPhantomJsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.SizzleLoadedSelectorPhantomJsTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "PhantomJs")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsSizzleLoadedSelectorPhantomJsTests : 
         WebDriverExtensionsSizzleSelectorTests, IClassFixture<PhantomJsFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.SizzleUnloadedSelectorPhantomJsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/PhantomJsTests/WebDriverExtensions.SizzleUnloadedSelectorPhantomJsTests.cs
@@ -7,6 +7,7 @@
     [Trait("Category", "Integration")]
     [Trait("Browser", "PhantomJs")]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class WebDriverExtensionsSizzleUnloadedSelectorPhantomJsTests :
         WebDriverExtensionsSizzleSelectorTests, IClassFixture<PhantomJsFixture>
     {

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.CoreTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.CoreTests.cs
@@ -2,7 +2,6 @@
 {
     using System.Diagnostics.CodeAnalysis;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions.Core;
     using Xunit;
     using By = Selenium.WebDriver.Extensions.By;
 

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.JQuerySelectorTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.JQuerySelectorTests.cs
@@ -3,8 +3,6 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions.Core;
-    using Selenium.WebDriver.Extensions.JQuery;
     using Xunit;
     using By = Selenium.WebDriver.Extensions.By;
 

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.JQuerySetterTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.JQuerySetterTests.cs
@@ -2,7 +2,6 @@
 {
     using System.Diagnostics.CodeAnalysis;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions.JQuery;
     using Xunit;
 
     [ExcludeFromCodeCoverage]

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.QuerySelectorTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.QuerySelectorTests.cs
@@ -2,7 +2,6 @@
 {
     using System.Diagnostics.CodeAnalysis;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions.Core;
     using Xunit;
     using By = Selenium.WebDriver.Extensions.By;
 

--- a/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.SizzleSelectorTests.cs
+++ b/test/Selenium.WebDriver.Extensions.IntegrationTests/Tests/WebDriverExtensions.SizzleSelectorTests.cs
@@ -2,7 +2,6 @@
 {
     using System.Diagnostics.CodeAnalysis;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions.Core;
     using Xunit;
     using By = Selenium.WebDriver.Extensions.By;
 

--- a/test/Selenium.WebDriver.Extensions.JQuery.Tests/Extensions/WebDriverExtensions.FindElementTests.cs
+++ b/test/Selenium.WebDriver.Extensions.JQuery.Tests/Extensions/WebDriverExtensions.FindElementTests.cs
@@ -1,0 +1,99 @@
+﻿namespace Selenium.WebDriver.Extensions.JQuery.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using Moq;
+    using OpenQA.Selenium;
+    using Xunit;
+    using By = Selenium.WebDriver.Extensions.JQuery.By;
+    
+    [Trait("Category", "Unit")]
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
+    public class WebDriverExtensionsFindElementTests
+    {
+        [Fact]
+        public void ShouldFindElement()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var element = new Mock<IWebElement>();
+            element.Setup(x => x.TagName).Returns("div");
+            var list = new List<IWebElement> { element.Object };
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript("return document.querySelectorAll('div');"))
+                .Returns(new ReadOnlyCollection<IWebElement>(list));
+            var result = driverMock.Object.FindElement(By.QuerySelector("div"));
+
+            Assert.NotNull(result);
+            Assert.Equal("div", result.TagName);
+        }
+
+        [Fact]
+        public void ShouldFindElementWithNestedSelector()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var element = new Mock<IWebElement>();
+            element.Setup(x => x.TagName).Returns("span");
+            var list = new List<IWebElement> { element.Object };
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("document.querySelectorAll\\('div'\\).length === 0")))
+                .Returns(new ReadOnlyCollection<IWebElement>(list));
+            var result = driverMock.Object.FindElement(By.QuerySelector("span", By.QuerySelector("div")));
+
+            Assert.NotNull(result);
+            Assert.Equal("span", result.TagName);
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementWithNullSelector()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => driverMock.Object.FindElement((Core.QuerySelector)null));
+            Assert.Equal("selector", ex.ParamName);
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementThatDoesNotExist()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            Assert.Throws<NoSuchElementException>(() => driverMock.Object.FindElement(By.QuerySelector("div")));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementReturnsEmptyResult()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript("return document.querySelectorAll('div');"))
+                .Returns(Enumerable.Empty<IWebElement>());
+
+            Assert.Throws<NoSuchElementException>(() => driverMock.Object.FindElement(By.QuerySelector("div")));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementWithNullDriver()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => WebDriverExtensions.FindElement(null, null));
+            Assert.Equal("driver", ex.ParamName);
+        }
+    }
+}

--- a/test/Selenium.WebDriver.Extensions.JQuery.Tests/Extensions/WebDriverExtensions.FindElementsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.JQuery.Tests/Extensions/WebDriverExtensions.FindElementsTests.cs
@@ -1,0 +1,113 @@
+﻿namespace Selenium.WebDriver.Extensions.JQuery.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics.CodeAnalysis;
+    using Moq;
+    using OpenQA.Selenium;
+    using Xunit;
+    using By = Selenium.WebDriver.Extensions.JQuery.By;
+
+    [Trait("Category", "Unit")]
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
+    public class WebDriverExtensionsFindElementsTests
+    {
+        [Fact]
+        public void ShouldFindElements()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var element1 = new Mock<IWebElement>();
+            element1.Setup(x => x.TagName).Returns("div");
+            element1.Setup(x => x.GetAttribute("class")).Returns("test");
+
+            var element2 = new Mock<IWebElement>();
+            element2.Setup(x => x.TagName).Returns("span");
+            element2.Setup(x => x.GetAttribute("class")).Returns("test");
+
+            var list = new List<IWebElement> { element1.Object, element2.Object };
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript("return document.querySelectorAll('.test');"))
+                .Returns(new ReadOnlyCollection<IWebElement>(list));
+            var result = driverMock.Object.FindElements(By.QuerySelector(".test"));
+
+            Assert.Equal(2, result.Count);
+
+            Assert.Equal("div", result[0].TagName);
+            Assert.Equal("test", result[0].GetAttribute("class"));
+
+            Assert.Equal("span", result[1].TagName);
+            Assert.Equal("test", result[1].GetAttribute("class"));
+        }
+
+        [Fact]
+        public void ShouldFindElementsWithNestedSelector()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var element1 = new Mock<IWebElement>();
+            element1.Setup(x => x.TagName).Returns("div");
+            element1.Setup(x => x.GetAttribute("class")).Returns("test");
+
+            var element2 = new Mock<IWebElement>();
+            element2.Setup(x => x.TagName).Returns("span");
+            element2.Setup(x => x.GetAttribute("class")).Returns("test");
+            
+            var list = new List<IWebElement> { element1.Object, element2.Object };
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("document.querySelectorAll\\('div'\\).length === 0")))
+                .Returns(new ReadOnlyCollection<IWebElement>(list));
+            var result = driverMock.Object.FindElements(By.QuerySelector(".test", By.QuerySelector("div")));
+
+            Assert.Equal(2, result.Count);
+
+            Assert.Equal("div", result[0].TagName);
+            Assert.Equal("test", result[0].GetAttribute("class"));
+
+            Assert.Equal("span", result[1].TagName);
+            Assert.Equal("test", result[1].GetAttribute("class"));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementsWithNullSelector()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => driverMock.Object.FindElements((Core.QuerySelector)null));
+            Assert.Equal("selector", ex.ParamName);
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyResultWhenFindingElementsThatDoesNotExist()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var list = new List<object>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript("return document.querySelectorAll('.test');"))
+                .Returns(new ReadOnlyCollection<object>(list));
+            var result = driverMock.Object.FindElements(By.QuerySelector(".test"));
+
+            Assert.Equal(0, result.Count);
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementsWithNullDriver()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => WebDriverExtensions.FindElements(null, null));
+            Assert.Equal("driver", ex.ParamName);
+        }
+    }
+}

--- a/test/Selenium.WebDriver.Extensions.JQuery.Tests/Extensions/WebDriverExtensions.OtherTests.cs
+++ b/test/Selenium.WebDriver.Extensions.JQuery.Tests/Extensions/WebDriverExtensions.OtherTests.cs
@@ -1,10 +1,9 @@
-﻿namespace Selenium.WebDriver.Extensions.Tests
+﻿namespace Selenium.WebDriver.Extensions.JQuery.Tests
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
     using Moq;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions;
     using Xunit;
     
     [Trait("Category", "Unit")]
@@ -59,7 +58,7 @@
             driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsAny<string>())).Returns(true);
 
             driverMock.Object.LoadExternalLibrary(
-                new JQuery.JQueryLoader(), 
+                new JQueryLoader(), 
                 new Uri("http://example.com"),
                 TimeSpan.FromMilliseconds(100));
             Assert.True(true);

--- a/test/Selenium.WebDriver.Extensions.JQuery.Tests/Selenium.WebDriver.Extensions.JQuery.Tests.csproj
+++ b/test/Selenium.WebDriver.Extensions.JQuery.Tests/Selenium.WebDriver.Extensions.JQuery.Tests.csproj
@@ -76,6 +76,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\WebDriverExtensions.FindElementsTests.cs" />
+    <Compile Include="Extensions\WebDriverExtensions.FindElementTests.cs" />
+    <Compile Include="Extensions\WebDriverExtensions.OtherTests.cs" />
     <Compile Include="Models\ByTests.cs" />
     <Compile Include="Loaders\JQueryLoaderTests.cs" />
     <Compile Include="Models\PositionTests.cs" />

--- a/test/Selenium.WebDriver.Extensions.JQuery.Tests/Selenium.WebDriver.Extensions.JQuery.Tests.csproj
+++ b/test/Selenium.WebDriver.Extensions.JQuery.Tests/Selenium.WebDriver.Extensions.JQuery.Tests.csproj
@@ -76,11 +76,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Extensions\WebDriverExtensionsTests.cs" />
-    <Compile Include="Extensions\WebElementExtensionsTests.cs" />
     <Compile Include="Models\ByTests.cs" />
     <Compile Include="Loaders\JQueryLoaderTests.cs" />
-    <Compile Include="Models\ChainJQueryHelperTests.cs" />
     <Compile Include="Models\PositionTests.cs" />
     <Compile Include="Models\JQueryHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Extensions/WebDriverExtensions.FindElementTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Extensions/WebDriverExtensions.FindElementTests.cs
@@ -1,0 +1,99 @@
+﻿namespace Selenium.WebDriver.Extensions.Sizzle.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using Moq;
+    using OpenQA.Selenium;
+    using Xunit;
+    using By = Selenium.WebDriver.Extensions.Sizzle.By;
+    
+    [Trait("Category", "Unit")]
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
+    public class WebDriverExtensionsFindElementTests
+    {
+        [Fact]
+        public void ShouldFindElement()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var element = new Mock<IWebElement>();
+            element.Setup(x => x.TagName).Returns("div");
+            var list = new List<IWebElement> { element.Object };
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript("return document.querySelectorAll('div');"))
+                .Returns(new ReadOnlyCollection<IWebElement>(list));
+            var result = driverMock.Object.FindElement(By.QuerySelector("div"));
+
+            Assert.NotNull(result);
+            Assert.Equal("div", result.TagName);
+        }
+
+        [Fact]
+        public void ShouldFindElementWithNestedSelector()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var element = new Mock<IWebElement>();
+            element.Setup(x => x.TagName).Returns("span");
+            var list = new List<IWebElement> { element.Object };
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("document.querySelectorAll\\('div'\\).length === 0")))
+                .Returns(new ReadOnlyCollection<IWebElement>(list));
+            var result = driverMock.Object.FindElement(By.QuerySelector("span", By.QuerySelector("div")));
+
+            Assert.NotNull(result);
+            Assert.Equal("span", result.TagName);
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementWithNullSelector()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => driverMock.Object.FindElement((Core.QuerySelector)null));
+            Assert.Equal("selector", ex.ParamName);
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementThatDoesNotExist()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            Assert.Throws<NoSuchElementException>(() => driverMock.Object.FindElement(By.QuerySelector("div")));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementReturnsEmptyResult()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript("return document.querySelectorAll('div');"))
+                .Returns(Enumerable.Empty<IWebElement>());
+
+            Assert.Throws<NoSuchElementException>(() => driverMock.Object.FindElement(By.QuerySelector("div")));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementWithNullDriver()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => WebDriverExtensions.FindElement(null, null));
+            Assert.Equal("driver", ex.ParamName);
+        }
+    }
+}

--- a/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Extensions/WebDriverExtensions.FindElementsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Extensions/WebDriverExtensions.FindElementsTests.cs
@@ -1,0 +1,113 @@
+﻿namespace Selenium.WebDriver.Extensions.Sizzle.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics.CodeAnalysis;
+    using Moq;
+    using OpenQA.Selenium;
+    using Xunit;
+    using By = Selenium.WebDriver.Extensions.Sizzle.By;
+
+    [Trait("Category", "Unit")]
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
+    public class WebDriverExtensionsFindElementsTests
+    {
+        [Fact]
+        public void ShouldFindElements()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var element1 = new Mock<IWebElement>();
+            element1.Setup(x => x.TagName).Returns("div");
+            element1.Setup(x => x.GetAttribute("class")).Returns("test");
+
+            var element2 = new Mock<IWebElement>();
+            element2.Setup(x => x.TagName).Returns("span");
+            element2.Setup(x => x.GetAttribute("class")).Returns("test");
+
+            var list = new List<IWebElement> { element1.Object, element2.Object };
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript("return document.querySelectorAll('.test');"))
+                .Returns(new ReadOnlyCollection<IWebElement>(list));
+            var result = driverMock.Object.FindElements(By.QuerySelector(".test"));
+
+            Assert.Equal(2, result.Count);
+
+            Assert.Equal("div", result[0].TagName);
+            Assert.Equal("test", result[0].GetAttribute("class"));
+
+            Assert.Equal("span", result[1].TagName);
+            Assert.Equal("test", result[1].GetAttribute("class"));
+        }
+
+        [Fact]
+        public void ShouldFindElementsWithNestedSelector()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var element1 = new Mock<IWebElement>();
+            element1.Setup(x => x.TagName).Returns("div");
+            element1.Setup(x => x.GetAttribute("class")).Returns("test");
+
+            var element2 = new Mock<IWebElement>();
+            element2.Setup(x => x.TagName).Returns("span");
+            element2.Setup(x => x.GetAttribute("class")).Returns("test");
+            
+            var list = new List<IWebElement> { element1.Object, element2.Object };
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("document.querySelectorAll\\('div'\\).length === 0")))
+                .Returns(new ReadOnlyCollection<IWebElement>(list));
+            var result = driverMock.Object.FindElements(By.QuerySelector(".test", By.QuerySelector("div")));
+
+            Assert.Equal(2, result.Count);
+
+            Assert.Equal("div", result[0].TagName);
+            Assert.Equal("test", result[0].GetAttribute("class"));
+
+            Assert.Equal("span", result[1].TagName);
+            Assert.Equal("test", result[1].GetAttribute("class"));
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementsWithNullSelector()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => driverMock.Object.FindElements((Core.QuerySelector)null));
+            Assert.Equal("selector", ex.ParamName);
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyResultWhenFindingElementsThatDoesNotExist()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
+
+            var list = new List<object>();
+            driverMock.As<IJavaScriptExecutor>()
+                .Setup(x => x.ExecuteScript("return document.querySelectorAll('.test');"))
+                .Returns(new ReadOnlyCollection<object>(list));
+            var result = driverMock.Object.FindElements(By.QuerySelector(".test"));
+
+            Assert.Equal(0, result.Count);
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWhenFindingElementsWithNullDriver()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => WebDriverExtensions.FindElements(null, null));
+            Assert.Equal("driver", ex.ParamName);
+        }
+    }
+}

--- a/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Extensions/WebDriverExtensions.OtherTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Extensions/WebDriverExtensions.OtherTests.cs
@@ -1,10 +1,9 @@
-﻿namespace Selenium.WebDriver.Extensions.Tests
+﻿namespace Selenium.WebDriver.Extensions.Sizzle.Tests
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
     using Moq;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions;
     using Xunit;
     
     [Trait("Category", "Unit")]
@@ -59,7 +58,7 @@
             driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsAny<string>())).Returns(true);
 
             driverMock.Object.LoadExternalLibrary(
-                new JQuery.JQueryLoader(), 
+                new SizzleLoader(), 
                 new Uri("http://example.com"),
                 TimeSpan.FromMilliseconds(100));
             Assert.True(true);

--- a/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Selenium.WebDriver.Extensions.Sizzle.Tests.csproj
+++ b/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Selenium.WebDriver.Extensions.Sizzle.Tests.csproj
@@ -76,7 +76,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Extensions\WebDriverExtensionsTests.cs" />
     <Compile Include="Models\ByTests.cs" />
     <Compile Include="Loaders\SizzleLoaderTests.cs" />
     <Compile Include="Models\SizzleHelperTests.cs" />

--- a/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Selenium.WebDriver.Extensions.Sizzle.Tests.csproj
+++ b/test/Selenium.WebDriver.Extensions.Sizzle.Tests/Selenium.WebDriver.Extensions.Sizzle.Tests.csproj
@@ -76,6 +76,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\WebDriverExtensions.FindElementsTests.cs" />
+    <Compile Include="Extensions\WebDriverExtensions.FindElementTests.cs" />
+    <Compile Include="Extensions\WebDriverExtensions.OtherTests.cs" />
     <Compile Include="Models\ByTests.cs" />
     <Compile Include="Loaders\SizzleLoaderTests.cs" />
     <Compile Include="Models\SizzleHelperTests.cs" />

--- a/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.ChainJQueryHelperTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.ChainJQueryHelperTests.cs
@@ -1,20 +1,21 @@
-﻿namespace Selenium.WebDriver.Extensions.JQuery.Tests
+﻿namespace Selenium.WebDriver.Extensions.Tests
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
     using Moq;
     using OpenQA.Selenium;
     using Xunit;
+    using By = Selenium.WebDriver.Extensions.By;
 
     [Trait("Category", "Unit")]
     [ExcludeFromCodeCoverage]
     [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
     [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
-    public class ChainJQueryHelperTests : IDisposable
+    public class WebDriverExtensionsChainJQueryHelperTests : IDisposable
     {
         private readonly IWebDriver driver;
 
-        public ChainJQueryHelperTests()
+        public WebDriverExtensionsChainJQueryHelperTests()
         {
             var mock = new Mock<IWebDriver>();
             mock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("window.jQuery"))).Returns(true);
@@ -30,7 +31,7 @@
         [Fact]
         public void ShouldThrowExceptionWhenGettingHelperWithNullSelector()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => this.driver.JQuery((JQuerySelector)null));
+            var ex = Assert.Throws<ArgumentNullException>(() => this.driver.JQuery((JQuery.JQuerySelector)null));
             Assert.Equal("selector", ex.ParamName);
         }
 
@@ -39,6 +40,13 @@
         {
             var ex = Assert.Throws<ArgumentNullException>(() => this.driver.JQuery((string)null));
             Assert.Equal("selector", ex.ParamName);
+        }
+
+        [Fact]
+        public void ShouldGetHelper()
+        {
+            var helper = this.driver.JQuery(By.JQuerySelector("input"));
+            Assert.NotNull(helper);
         }
 
         [Fact]
@@ -260,7 +268,7 @@
         [Fact]
         public void ShouldShowEnum()
         {
-            var result = this.driver.JQuery("div").Show(Duration.Fast);
+            var result = this.driver.JQuery("div").Show(JQuery.Duration.Fast);
 
             Assert.NotNull(result);
         }
@@ -284,7 +292,7 @@
         [Fact]
         public void ShouldHideEnum()
         {
-            var result = this.driver.JQuery("div").Hide(Duration.Slow);
+            var result = this.driver.JQuery("div").Hide(JQuery.Duration.Slow);
 
             Assert.NotNull(result);
         }
@@ -308,7 +316,7 @@
         [Fact]
         public void ShouldToggleEnum()
         {
-            var result = this.driver.JQuery("div").Toggle(Duration.Fast);
+            var result = this.driver.JQuery("div").Toggle(JQuery.Duration.Fast);
 
             Assert.NotNull(result);
         }
@@ -332,7 +340,7 @@
         [Fact]
         public void ShouldSlideDownEnum()
         {
-            var result = this.driver.JQuery("div").SlideDown(Duration.Fast);
+            var result = this.driver.JQuery("div").SlideDown(JQuery.Duration.Fast);
 
             Assert.NotNull(result);
         }
@@ -356,7 +364,7 @@
         [Fact]
         public void ShouldSlideUpEnum()
         {
-            var result = this.driver.JQuery("div").SlideUp(Duration.Fast);
+            var result = this.driver.JQuery("div").SlideUp(JQuery.Duration.Fast);
 
             Assert.NotNull(result);
         }
@@ -380,7 +388,7 @@
         [Fact]
         public void ShouldSlideToggleEnum()
         {
-            var result = this.driver.JQuery("div").SlideToggle(Duration.Slow);
+            var result = this.driver.JQuery("div").SlideToggle(JQuery.Duration.Slow);
 
             Assert.NotNull(result);
         }
@@ -404,7 +412,7 @@
         [Fact]
         public void ShouldFadeInEnum()
         {
-            var result = this.driver.JQuery("div").FadeIn(Duration.Slow);
+            var result = this.driver.JQuery("div").FadeIn(JQuery.Duration.Slow);
 
             Assert.NotNull(result);
         }
@@ -428,7 +436,7 @@
         [Fact]
         public void ShouldFadeOutEnum()
         {
-            var result = this.driver.JQuery("div").FadeOut(Duration.Slow);
+            var result = this.driver.JQuery("div").FadeOut(JQuery.Duration.Slow);
 
             Assert.NotNull(result);
         }
@@ -452,7 +460,7 @@
         [Fact]
         public void ShouldFadeToggleEnum()
         {
-            var result = this.driver.JQuery("div").FadeToggle(Duration.Slow);
+            var result = this.driver.JQuery("div").FadeToggle(JQuery.Duration.Slow);
 
             Assert.NotNull(result);
         }
@@ -484,7 +492,7 @@
         [Fact]
         public void ShouldFadeToGivenDuration()
         {
-            var result = this.driver.JQuery("div").FadeTo(Duration.Slow, 0.5m);
+            var result = this.driver.JQuery("div").FadeTo(JQuery.Duration.Slow, 0.5m);
 
             Assert.NotNull(result);
         }
@@ -506,14 +514,16 @@
         [Fact]
         public void ShouldFadeToEnumNegativeOpacity()
         {
-            var ex = Assert.Throws<ArgumentException>(() => this.driver.JQuery("div").FadeTo(Duration.Slow, -1m));
+            var ex = Assert.Throws<ArgumentException>(() => this.driver.JQuery("div")
+                .FadeTo(JQuery.Duration.Slow, -1m));
             Assert.Equal("opacity", ex.ParamName);
         }
 
         [Fact]
         public void ShouldFadeToEnumOpacityBiggerThanOne()
         {
-            var ex = Assert.Throws<ArgumentException>(() => this.driver.JQuery("div").FadeTo(Duration.Slow, 2m));
+            var ex = Assert.Throws<ArgumentException>(() => this.driver.JQuery("div")
+                .FadeTo(JQuery.Duration.Slow, 2m));
             Assert.Equal("opacity", ex.ParamName);
         }
 

--- a/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.FindElementTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.FindElementTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Selenium.WebDriver.Extensions.Core.Tests
+﻿namespace Selenium.WebDriver.Extensions.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -7,9 +7,10 @@
     using System.Linq;
     using Moq;
     using OpenQA.Selenium;
+    using Selenium.WebDriver.Extensions;
     using Xunit;
-    using By = Selenium.WebDriver.Extensions.Core.By;
-
+    using By = Selenium.WebDriver.Extensions.By;
+    
     [Trait("Category", "Unit")]
     [ExcludeFromCodeCoverage]
     [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
@@ -61,7 +62,8 @@
             driverMock.As<IJavaScriptExecutor>()
                 .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
 
-            var ex = Assert.Throws<ArgumentNullException>(() => driverMock.Object.FindElement((QuerySelector)null));
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => driverMock.Object.FindElement((Core.QuerySelector)null));
             Assert.Equal("selector", ex.ParamName);
         }
 

--- a/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.FindElementsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.FindElementsTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Selenium.WebDriver.Extensions.Core.Tests
+﻿namespace Selenium.WebDriver.Extensions.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -6,8 +6,9 @@
     using System.Diagnostics.CodeAnalysis;
     using Moq;
     using OpenQA.Selenium;
+    using Selenium.WebDriver.Extensions;
     using Xunit;
-    using By = Selenium.WebDriver.Extensions.Core.By;
+    using By = Selenium.WebDriver.Extensions.By;
 
     [Trait("Category", "Unit")]
     [ExcludeFromCodeCoverage]
@@ -82,7 +83,8 @@
             driverMock.As<IJavaScriptExecutor>()
                 .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(true);
 
-            var ex = Assert.Throws<ArgumentNullException>(() => driverMock.Object.FindElements((QuerySelector)null));
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => driverMock.Object.FindElements((Core.QuerySelector)null));
             Assert.Equal("selector", ex.ParamName);
         }
 

--- a/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.JQueryTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.JQueryTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Selenium.WebDriver.Extensions.JQuery.Tests
+﻿namespace Selenium.WebDriver.Extensions.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -7,16 +7,15 @@
     using System.Linq;
     using Moq;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions.Core;
-    using Selenium.WebDriver.Extensions.JQuery;
+    using Selenium.WebDriver.Extensions;
     using Xunit;
-    using By = Selenium.WebDriver.Extensions.JQuery.By;
+    using By = Selenium.WebDriver.Extensions.By;
 
     [Trait("Category", "Unit")]
     [ExcludeFromCodeCoverage]
     [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
     [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
-    public class WebDriverExtensionsTests
+    public class WebDriverExtensionsJQueryTests
     {
         public static IEnumerable<object[]> LoadJQueryData
         {
@@ -93,7 +92,8 @@
             driverMock.As<IJavaScriptExecutor>()
                 .Setup(x => x.ExecuteScript(It.IsRegex("window.jQuery"))).Returns(true); 
             
-            var ex = Assert.Throws<ArgumentNullException>(() => driverMock.Object.FindElement((JQuerySelector)null));
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => driverMock.Object.FindElement((JQuery.JQuerySelector)null));
             Assert.Equal("selector", ex.ParamName);
         }
 
@@ -258,7 +258,7 @@
             var driverMock = new Mock<IWebDriver>();
             driverMock.As<IJavaScriptExecutor>()
                 .Setup(x => x.ExecuteScript(It.IsRegex("window.jQuery"))).Returns(true);
-            var ex = Assert.Throws<TypeArgumentException>(
+            var ex = Assert.Throws<Core.TypeArgumentException>(
                 () => driverMock.Object.JQuery("input").Property<int>("checked"));
             Assert.Equal("T", ex.ParamName);
         }
@@ -508,7 +508,8 @@
             var driverMock = new Mock<IWebDriver>();
             driverMock.As<IJavaScriptExecutor>()
                 .Setup(x => x.ExecuteScript(It.IsRegex("window.jQuery"))).Returns(true);
-            var ex = Assert.Throws<TypeArgumentException>(() => driverMock.Object.JQuery("input").Data<int>("test"));
+            var ex = Assert.Throws<Core.TypeArgumentException>(() => driverMock.Object.JQuery("input")
+                .Data<int>("test"));
             Assert.Equal("T", ex.ParamName);
         }
 
@@ -583,21 +584,21 @@
         public void ShouldThrowExceptionWhenGettingHelperWithNullSelector()
         {
             var ex = Assert.Throws<ArgumentNullException>(
-                () => JQuery.WebDriverExtensions.JQuery(null, (JQuerySelector)null));
+                () => WebDriverExtensions.JQuery(null, (JQuery.JQuerySelector)null));
             Assert.Equal("driver", ex.ParamName);
         }
 
         [Fact]
         public void ShouldThrowExceptionWhenGettingHelperWithNullStringSelector()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => JQuery.WebDriverExtensions.JQuery(null, (string)null));
+            var ex = Assert.Throws<ArgumentNullException>(() => WebDriverExtensions.JQuery(null, (string)null));
             Assert.Equal("driver", ex.ParamName);
         }
 
         [Fact]
         public void ShouldThrowExceptionWhenGettingJQueryHelperWithNullDriver()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => JQuery.WebDriverExtensions.JQuery(null));
+            var ex = Assert.Throws<ArgumentNullException>(() => WebDriverExtensions.JQuery(null));
             Assert.Equal("driver", ex.ParamName);
         }
     }

--- a/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.OtherTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.OtherTests.cs
@@ -1,11 +1,12 @@
-﻿namespace Selenium.WebDriver.Extensions.Core.Tests
+﻿namespace Selenium.WebDriver.Extensions.Tests
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
     using Moq;
     using OpenQA.Selenium;
+    using Selenium.WebDriver.Extensions;
     using Xunit;
-
+    
     [Trait("Category", "Unit")]
     [ExcludeFromCodeCoverage]
     [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
@@ -18,7 +19,8 @@
             var driverMock = new Mock<IWebDriver>();
             driverMock.As<IJavaScriptExecutor>()
                 .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(false);
-            Assert.Throws<QuerySelectorNotSupportedException>(() => driverMock.Object.QuerySelector().CheckSupport());
+            Assert.Throws<Core.QuerySelectorNotSupportedException>(
+                () => driverMock.Object.QuerySelector().CheckSupport());
         }
 
         [Fact]
@@ -47,7 +49,20 @@
             driverMock.As<IJavaScriptExecutor>()
                 .Setup(x => x.ExecuteScript(It.IsRegex("\\(document.querySelectorAll\\)"))).Returns(null);
 
-            Assert.False(driverMock.Object.CheckSelectorPrerequisites(new QuerySelectorLoader()));
+            Assert.False(driverMock.Object.CheckSelectorPrerequisites(new Core.QuerySelectorLoader()));
+        }
+
+        [Fact]
+        public void ShouldLoadingExternalLibrary()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsAny<string>())).Returns(true);
+
+            driverMock.Object.LoadExternalLibrary(
+                new JQuery.JQueryLoader(), 
+                new Uri("http://example.com"),
+                TimeSpan.FromMilliseconds(100));
+            Assert.True(true);
         }
 
         [Fact]
@@ -81,6 +96,26 @@
         {
             var ex = Assert.Throws<ArgumentNullException>(() => WebDriverExtensions.ExecuteScript<object>(null, null));
             Assert.Equal("driver", ex.ParamName);
+        }
+
+        [Fact]
+        public void ShouldExecuteScript()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsAny<string>())).Returns("foo");
+            
+            driverMock.Object.ExecuteScript("myMethod();");
+            Assert.True(true);
+        }
+
+        [Fact]
+        public void ShouldExecuteScriptThatReturnsValue()
+        {
+            var driverMock = new Mock<IWebDriver>();
+            driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsAny<string>())).Returns("foo");
+
+            var result = driverMock.Object.ExecuteScript<string>("return 'foo';");
+            Assert.Equal("foo", result);
         }
 
         [Fact]

--- a/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.SizzleTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebDriverExtensions.SizzleTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Selenium.WebDriver.Extensions.Sizzle.Tests
+﻿namespace Selenium.WebDriver.Extensions.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -7,16 +7,14 @@
     using System.Linq;
     using Moq;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions.Core;
-    using Selenium.WebDriver.Extensions.Sizzle;
     using Xunit;
-    using By = Selenium.WebDriver.Extensions.Sizzle.By;
+    using By = Selenium.WebDriver.Extensions.By;
 
     [Trait("Category", "Unit")]
     [ExcludeFromCodeCoverage]
     [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
     [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
-    public class WebDriverExtensionsTests
+    public class WebDriverExtensionsSizzleTests
     {
         public static IEnumerable<object[]> LoadSizzleData
         {
@@ -94,7 +92,8 @@
             driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("window.Sizzle")))
                 .Returns(true);
 
-            var ex = Assert.Throws<ArgumentNullException>(() => driverMock.Object.FindElement((SizzleSelector)null));
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => driverMock.Object.FindElement((Sizzle.SizzleSelector)null));
             Assert.Equal("selector", ex.ParamName);
         }
 
@@ -169,7 +168,7 @@
         [Fact]
         public void ShouldThrowExceptionWhenGettingSizzleHelperWithNullDriver()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => Sizzle.WebDriverExtensions.Sizzle(null));
+            var ex = Assert.Throws<ArgumentNullException>(() => WebDriverExtensions.Sizzle(null));
             Assert.Equal("driver", ex.ParamName);
         }
     }

--- a/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebElementExtensionsTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Extensions/WebElementExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Selenium.WebDriver.Extensions.JQuery.Tests
+﻿namespace Selenium.WebDriver.Extensions.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -6,9 +6,9 @@
     using System.Diagnostics.CodeAnalysis;
     using Moq;
     using OpenQA.Selenium;
-    using Selenium.WebDriver.Extensions.Core;
+    using Selenium.WebDriver.Extensions;
     using Xunit;
-    using By = Selenium.WebDriver.Extensions.JQuery.By;
+    using By = Selenium.WebDriver.Extensions.By;
 
     [Trait("Category", "Unit")]
     [ExcludeFromCodeCoverage]
@@ -52,7 +52,7 @@
                 .Setup(x => x.ExecuteScript("return jQuery('span', jQuery('body > div')).get();"))
                 .Returns(new ReadOnlyCollection<IWebElement>(elementList));
             
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -89,7 +89,7 @@
                 .Setup(x => x.ExecuteScript("return jQuery('span', jQuery('body > div')).get();"))
                 .Returns(new ReadOnlyCollection<IWebElement>(elementList));
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -114,7 +114,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
             
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -134,7 +134,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
             
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -154,7 +154,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
             
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -174,7 +174,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -194,7 +194,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -214,7 +214,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -234,7 +234,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -253,7 +253,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -272,7 +272,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -292,7 +292,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -312,7 +312,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -332,7 +332,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -352,7 +352,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -372,7 +372,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -392,7 +392,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -414,7 +414,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -439,7 +439,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -462,7 +462,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -482,7 +482,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -502,7 +502,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -522,7 +522,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -542,7 +542,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -562,7 +562,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -582,7 +582,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -602,7 +602,7 @@
             this.driverMock.As<IJavaScriptExecutor>().Setup(x => x.ExecuteScript(It.IsRegex("function\\(element\\)")))
                 .Returns("body > div");
 
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             webElement.SetupGet(x => x.TagName).Returns("div");
             webElement.SetupGet(x => x.Selector).Returns(selector);
             webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
@@ -613,10 +613,20 @@
         }
 
         [Fact]
+        public void ShouldGetHelper()
+        {
+            var webElement = new Mock<Core.WebElement>();
+            webElement.SetupGet(x => x.WrappedDriver).Returns(this.driverMock.Object);
+
+            webElement.Object.JQuery(By.JQuerySelector("input"));
+            Assert.True(true);
+        }
+
+        [Fact]
         public void ShouldThrowExceptionWhenGettingHelperWithNullSelectorAndNullWebElement()
         {
             var ex = Assert.Throws<ArgumentNullException>(
-                () => WebElementExtensions.JQuery(null, (JQuerySelector)null));
+                () => WebElementExtensions.JQuery(null, (JQuery.JQuerySelector)null));
             Assert.Equal("webElement", ex.ParamName);
         }
 
@@ -630,15 +640,15 @@
         [Fact]
         public void ShouldThrowExceptionWhenGettingHelperWithNullSelector()
         {
-            var webElement = new Mock<WebElement>();
-            var ex = Assert.Throws<ArgumentNullException>(() => webElement.Object.JQuery((JQuerySelector)null));
+            var webElement = new Mock<Core.WebElement>();
+            var ex = Assert.Throws<ArgumentNullException>(() => webElement.Object.JQuery((JQuery.JQuerySelector)null));
             Assert.Equal("selector", ex.ParamName);
         }
 
         [Fact]
         public void ShouldThrowExceptionWhenGettingHelperWithNullStringSelector()
         {
-            var webElement = new Mock<WebElement>();
+            var webElement = new Mock<Core.WebElement>();
             var ex = Assert.Throws<ArgumentNullException>(() => webElement.Object.JQuery((string)null));
             Assert.Equal("selector", ex.ParamName);
         }

--- a/test/Selenium.WebDriver.Extensions.Tests/Models/ByTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Models/ByTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Selenium.WebDriver.Extensions.Core;
     using Xunit;
     using By = Selenium.WebDriver.Extensions.By;
 
@@ -153,7 +152,7 @@
         [Fact]
         public void ShouldThrowExceptionWhenCreatingQuerySelectorWithNullBaseSelector()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() => By.QuerySelector("div", (ISelector)null));
+            var ex = Assert.Throws<ArgumentNullException>(() => By.QuerySelector("div", (Core.ISelector)null));
             Assert.Equal("baseSelector", ex.ParamName);
         }
 

--- a/test/Selenium.WebDriver.Extensions.Tests/Models/ByTests.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Models/ByTests.cs
@@ -8,6 +8,7 @@
     [Trait("Category", "Unit")]
     [ExcludeFromCodeCoverage]
     [SuppressMessage("ReSharper", "ExceptionNotDocumented")]
+    [SuppressMessage("ReSharper", "ExceptionNotDocumentedOptional")]
     public class ByTests
     {
         [Fact]

--- a/test/Selenium.WebDriver.Extensions.Tests/Properties/AssemblyInfo.cs
+++ b/test/Selenium.WebDriver.Extensions.Tests/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]

--- a/test/Selenium.WebDriver.Extensions.Tests/Selenium.WebDriver.Extensions.Tests.csproj
+++ b/test/Selenium.WebDriver.Extensions.Tests/Selenium.WebDriver.Extensions.Tests.csproj
@@ -57,6 +57,9 @@
     <OutputPath>bin\Mono\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
@@ -73,6 +76,13 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\WebDriverExtensions.FindElementsTests.cs" />
+    <Compile Include="Extensions\WebDriverExtensions.FindElementTests.cs" />
+    <Compile Include="Extensions\WebDriverExtensions.OtherTests.cs" />
+    <Compile Include="Extensions\WebDriverExtensions.JQueryTests.cs" />
+    <Compile Include="Extensions\WebDriverExtensions.SizzleTests.cs" />
+    <Compile Include="Extensions\WebElementExtensionsTests.cs" />
+    <Compile Include="Extensions\WebDriverExtensions.ChainJQueryHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Models\ByTests.cs" />
   </ItemGroup>

--- a/test/Selenium.WebDriver.Extensions.Tests/Selenium.WebDriver.Extensions.Tests.csproj.DotSettings
+++ b/test/Selenium.WebDriver.Extensions.Tests/Selenium.WebDriver.Extensions.Tests.csproj.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=extensions/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=models/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/test/Selenium.WebDriver.Extensions.Tests/packages.config
+++ b/test/Selenium.WebDriver.Extensions.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="2.45.0" targetFramework="net45" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
In the current state of the application the extension methods are only available in Core, JQuery and Sizzle projects and you must load the specific namespace in order to use the extensions out of it. This change creates a wrappers for those extension methods and defines it in Selenium.WebDriver.Extensions namespace so those specific namespace declarations are going to be redundant.

In an example if you want to run a jQuery selector with the "full" package you must do this
```csharp
using Selenium.WebDriver.Extensions.Core;
using By = Selenium.WebDriver.Extensions.By;
```

With the new wrappers this can be simplified to
```csharp
using Selenium.WebDriver.Extensions;
using By = Selenium.WebDriver.Extensions.By;
```

Fixes #84 